### PR TITLE
fix: clear qr refresh interval on client.destroy() (#249)

### DIFF
--- a/src/Client.js
+++ b/src/Client.js
@@ -118,11 +118,12 @@ class Client extends EventEmitter {
                 this.emit(Events.QR_RECEIVED, qr);
             };
             getQrCode();
-            let retryInterval = setInterval(getQrCode, this.options.qrRefreshIntervalMs);
+            this._qrRefreshInterval = setInterval(getQrCode, this.options.qrRefreshIntervalMs);
 
             // Wait for code scan
             await page.waitForSelector(KEEP_PHONE_CONNECTED_IMG_SELECTOR, { timeout: 0 });
-            clearInterval(retryInterval);
+            clearInterval(this._qrRefreshInterval);
+            this._qrRefreshInterval = undefined;
 
         }
 
@@ -352,6 +353,9 @@ class Client extends EventEmitter {
      * Closes the client
      */
     async destroy() {
+        if (this._qrRefreshInterval) {
+            clearInterval(this._qrRefreshInterval);
+        }
         await this.pupBrowser.close();
     }
 


### PR DESCRIPTION
* fix: client.destroy() keeps trying to get QR code when client is not authorized yet

Co-authored-by: Javier Portillo <javier.marquez@dada-dada.com>